### PR TITLE
Adjust date and temperature for Strava

### DIFF
--- a/exportTemplates/gpx_ext.txt
+++ b/exportTemplates/gpx_ext.txt
@@ -7,6 +7,10 @@ xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
 
+<metadata>
+   <time>$track.trackpoints[0].date.isoformat()</time>
+</metadata>
+
 <% for i, track in enumerate(tracks) %>
 <trk>
 	<number>$i</number>

--- a/gb580.py
+++ b/gb580.py
@@ -78,7 +78,7 @@ class Trackpoint(Point):
             self.cadence    = int(Utilities.swap(hex[48:52]), 16)
             self.pwrcadence = int(Utilities.swap(hex[42:56]), 16)
             self.power      = int(Utilities.swap(hex[56:60]), 16)
-            self.temp       = int(Utilities.swap(hex[60:64]), 16)
+            self.temp       = int(Utilities.swap(hex[60:64]), 16) / 10.0
             return self
         else:
             raise GB500ParseException(self.__class__.__name__, len(hex), 64)

--- a/gb580.py
+++ b/gb580.py
@@ -71,7 +71,7 @@ class Trackpoint(Point):
             self.latitude   = Coordinate().fromHex(Utilities.swap(hex[0:8]))
             self.longitude  = Coordinate().fromHex(Utilities.swap(hex[8:16]))
             self.altitude   = Utilities.hex2signedDec(Utilities.swap(hex[16:20]))
-            self.speed      = int(Utilities.swap(hex[24:32]), 16)/100
+            self.speed      = int(Utilities.swap(hex[24:32]), 16) / 100.0
             self.heartrate  = int(Utilities.swap(hex[32:34]), 16)
             self.interval   = int(Utilities.swap(hex[40:48]), 16)
             #self.interval   = datetime.timedelta(seconds=Utilities.hex2dec(hex[40:48])/10.0)


### PR DESCRIPTION
Exported tracks have temperature multiplied by 10, Strava does not like
that and ignores it.

Also, Strava ignores time stamps unless there is a base time in
metadata.

This fixes both.

Signed-off-by: Alexey Kardashevskiy <aik@ozlabs.ru>